### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/profile-3d.yml
+++ b/.github/workflows/profile-3d.yml
@@ -12,6 +12,8 @@ jobs:
   build:
     runs-on: ubuntu-latest
     name: generate-github-profile-3d-contrib
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@v2
       - uses: yoshi389111/github-profile-3d-contrib@0.6.0


### PR DESCRIPTION
Potential fix for [https://github.com/ClaudioMendonca-Eng/ClaudioMendonca-Eng/security/code-scanning/1](https://github.com/ClaudioMendonca-Eng/ClaudioMendonca-Eng/security/code-scanning/1)

To fix the issue, we need to add a `permissions` block to the workflow. This block should specify the least privileges required for the workflow to function correctly. Based on the workflow's actions:
- `contents: write` is required for committing and pushing changes.
- Other permissions can be set to `read` or omitted entirely if not needed.

The `permissions` block can be added at the root level of the workflow to apply to all jobs, or it can be added specifically to the `build` job.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
